### PR TITLE
Add CosmosDB backend for the Accounts DB in Dendrite

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,19 @@
                 "${workspaceFolder}\\bin\\dendrite.yaml",
                 "clientapi",
             ]
-        }
+        },
+        {
+            "name": "Launch Package Monolith - CosmosDB",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}\\cmd\\dendrite-monolith-server",
+            "args": [
+                "-config",
+                "${workspaceFolder}\\dendrite-config-cosmosdb.yaml",
+                //Uncomment below to expose internal api's
+                // "--api",
+                // "true"
+            ]}
     ]
 }

--- a/dendrite-config-cosmosdb.yaml
+++ b/dendrite-config-cosmosdb.yaml
@@ -90,7 +90,7 @@ global:
 
     # Naffka database options. Not required when using Kafka.
     naffka_database:
-      connection_string: cosmosdb:naffka.db
+      connection_string: file:naffka.db
       max_open_conns: 10
       max_idle_conns: 2
       conn_max_lifetime: -1
@@ -122,7 +122,7 @@ app_service_api:
     listen: http://localhost:7777
     connect: http://localhost:7777
   database:
-    connection_string: cosmosdb:appservice.db
+    connection_string: file:appservice.db
     max_open_conns: 10
     max_idle_conns: 2
     conn_max_lifetime: -1
@@ -202,7 +202,7 @@ federation_sender:
     listen: http://localhost:7775
     connect: http://localhost:7775
   database:
-    connection_string: cosmosdb:federationsender.db
+    connection_string: file:federationsender.db
     max_open_conns: 10
     max_idle_conns: 2
     conn_max_lifetime: -1
@@ -228,7 +228,7 @@ key_server:
     listen: http://localhost:7779
     connect: http://localhost:7779
   database:
-    connection_string: cosmosdb:keyserver.db
+    connection_string: file:keyserver.db
     max_open_conns: 10
     max_idle_conns: 2
     conn_max_lifetime: -1
@@ -241,7 +241,7 @@ media_api:
   external_api:
     listen: http://[::]:8074
   database:
-    connection_string: cosmosdb:mediaapi.db
+    connection_string: file:mediaapi.db
     max_open_conns: 5
     max_idle_conns: 2
     conn_max_lifetime: -1
@@ -280,7 +280,7 @@ mscs:
   # - msc2946    (Spaces Summary, see https://github.com/matrix-org/matrix-doc/pull/2946)
   mscs: []
   database:
-    connection_string: cosmosdb:mscs.db
+    connection_string: file:mscs.db
     max_open_conns: 5
     max_idle_conns: 2
     conn_max_lifetime: -1
@@ -291,7 +291,7 @@ room_server:
     listen: http://localhost:7770
     connect: http://localhost:7770
   database:
-    connection_string: cosmosdb:roomserver.db
+    connection_string: file:roomserver.db
     max_open_conns: 10
     max_idle_conns: 2
     conn_max_lifetime: -1
@@ -302,7 +302,7 @@ signing_key_server:
     listen: http://localhost:7780
     connect: http://localhost:7780
   database:
-    connection_string: cosmosdb:signingkeyserver.db
+    connection_string: file:signingkeyserver.db
     max_open_conns: 10
     max_idle_conns: 2
     conn_max_lifetime: -1
@@ -331,7 +331,7 @@ sync_api:
   external_api:
     listen: http://[::]:8073
   database:
-    connection_string: cosmosdb:syncapi.db
+    connection_string: file:syncapi.db
     max_open_conns: 10
     max_idle_conns: 2
     conn_max_lifetime: -1
@@ -354,12 +354,12 @@ user_api:
     listen: http://localhost:7781
     connect: http://localhost:7781
   account_database:
-    connection_string: cosmosdb:userapi_accounts.db
+    connection_string: "cosmosdb:AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
     max_open_conns: 10
     max_idle_conns: 2
     conn_max_lifetime: -1
   device_database:
-    connection_string: cosmosdb:userapi_devices.db
+    connection_string: file:userapi_devices.db
     max_open_conns: 10
     max_idle_conns: 2
     conn_max_lifetime: -1

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/tidwall/sjson v1.1.5
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/uber/jaeger-lib v2.4.0+incompatible
+	github.com/vippsas/go-cosmosdb v0.0.0-20200428065936-29dab535353d // indirect
 	github.com/yggdrasil-network/yggdrasil-go v0.3.15-0.20210218094457-e77ca8019daa
 	go.uber.org/atomic v1.7.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -176,6 +177,7 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/gofrs/uuid v3.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -987,6 +989,8 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
+github.com/vippsas/go-cosmosdb v0.0.0-20200428065936-29dab535353d h1:MZRYOouO0snrQyBAf4Wljc3qqaispjzMOhFRQgWfKMo=
+github.com/vippsas/go-cosmosdb v0.0.0-20200428065936-29dab535353d/go.mod h1:ldPlejlc7ZyiP0QQWGwL9CoZLvEjhD9yzpz0ct7+sXo=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=

--- a/internal/cosmosdbapi/client.go
+++ b/internal/cosmosdbapi/client.go
@@ -1,0 +1,24 @@
+package cosmosdbapi
+
+import (
+	cosmosapi "github.com/vippsas/go-cosmosdb/cosmosapi"
+)
+
+type CosmosConnection struct {
+	Url string
+	Key string
+}
+
+func GetCosmosConnection(accountEndpoint string, accountKey string) CosmosConnection {
+	return CosmosConnection{
+		Url: accountEndpoint,
+		Key: accountKey,
+	}
+}
+
+func GetClient(conn CosmosConnection) *cosmosapi.Client {
+	cfg := cosmosapi.Config{
+		MasterKey: conn.Key,
+	}
+	return cosmosapi.New(conn.Url, cfg, nil, nil)
+}

--- a/internal/cosmosdbapi/collection.go
+++ b/internal/cosmosdbapi/collection.go
@@ -1,0 +1,10 @@
+package cosmosdbapi
+
+import (
+	"fmt"
+
+)
+
+func GetCollectionName(databaseName string, tableName string) string {
+	return fmt.Sprintf("matrix_%s_%s", databaseName, tableName)
+}

--- a/internal/cosmosdbapi/document.go
+++ b/internal/cosmosdbapi/document.go
@@ -1,0 +1,14 @@
+package cosmosdbapi
+
+import (
+	"fmt"
+
+)
+
+func GetDocumentId(tenantName string, collectionName string, id string) string {
+	return fmt.Sprintf("%s,%s,%s", collectionName, tenantName, id)
+}
+
+func GetPartitionKey(tenantName string, collectionName string) string {
+	return fmt.Sprintf("%s,%s", collectionName, tenantName)
+}

--- a/internal/cosmosdbapi/documentoperations.go
+++ b/internal/cosmosdbapi/documentoperations.go
@@ -1,0 +1,46 @@
+package cosmosdbapi
+
+import (
+	cosmosapi "github.com/vippsas/go-cosmosdb/cosmosapi"
+)
+
+func GetCreateDocumentOptions(pk string) cosmosapi.CreateDocumentOptions {
+	return cosmosapi.CreateDocumentOptions{
+		IsUpsert: false,
+		PartitionKeyValue: pk,
+	}
+}
+
+func GetUpsertDocumentOptions(pk string) cosmosapi.CreateDocumentOptions {
+	return cosmosapi.CreateDocumentOptions{
+		IsUpsert: true,
+		PartitionKeyValue: pk,
+	}
+}
+
+func GetQueryDocumentsOptions(pk string) cosmosapi.QueryDocumentsOptions {
+	return cosmosapi.QueryDocumentsOptions{
+		PartitionKeyValue: pk,
+		IsQuery: true,
+		ContentType: cosmosapi.QUERY_CONTENT_TYPE,
+	}
+}
+
+func GetGetDocumentOptions(pk string) cosmosapi.GetDocumentOptions {
+	return cosmosapi.GetDocumentOptions{
+		PartitionKeyValue: pk,
+	}
+}
+
+func GetReplaceDocumentOptions(pk string, etag string) cosmosapi.ReplaceDocumentOptions {
+	return cosmosapi.ReplaceDocumentOptions{
+		PartitionKeyValue: pk,
+		IfMatch: etag,
+	}
+}
+
+func GetDeleteDocumentOptions(pk string) cosmosapi.DeleteDocumentOptions {
+	return cosmosapi.DeleteDocumentOptions{
+		PartitionKeyValue: pk,
+	}
+}

--- a/internal/cosmosdbapi/query.go
+++ b/internal/cosmosdbapi/query.go
@@ -1,0 +1,20 @@
+package cosmosdbapi
+
+import (
+	cosmosapi "github.com/vippsas/go-cosmosdb/cosmosapi"
+)
+
+func GetQuery(qry string, params map[string]interface{}) cosmosapi.Query {
+	qryParams := []cosmosapi.QueryParam{}
+	for key, value := range params {
+        qryParam := cosmosapi.QueryParam {
+			Name: key,
+			Value: value,
+		}
+		qryParams = append(qryParams, qryParam)
+    }
+	return cosmosapi.Query {
+		Query: qry,
+		Params: qryParams,
+	}
+}

--- a/internal/cosmosdbapi/tenant.go
+++ b/internal/cosmosdbapi/tenant.go
@@ -1,0 +1,14 @@
+package cosmosdbapi
+
+type Tenant struct {
+	DatabaseName string
+	TenantName   string
+}
+
+//TODO: Move into Config or the JWT
+func DefaultConfig() Tenant {
+	return Tenant{
+		DatabaseName: "safezone_local",
+		TenantName:   "criticalarc.com",
+	}
+}

--- a/internal/cosmosdbutil/connection.go
+++ b/internal/cosmosdbutil/connection.go
@@ -8,5 +8,15 @@ import (
 func GetConnectionString(d *config.DataSource) config.DataSource {
 	var connString string
 	connString = string(*d)
-	return config.DataSource(strings.Replace(connString, "cosmosdb:", "file:", 1))
+	return config.DataSource(strings.Replace(connString, "cosmosdb:", "", 1))
+}
+
+func GetConnectionProperties(connectionString string) map[string]string {
+	connectionItemsRaw := strings.Split(connectionString, ";")
+	connectionItems := map[string]string{}
+	for _, item := range connectionItemsRaw {
+		itemSplit := strings.SplitN(item, "=", 2)
+		connectionItems[itemSplit[0]] = itemSplit[1]
+	}
+	return connectionItems
 }

--- a/userapi/storage/accounts/cosmosdb/accounts_table.go
+++ b/userapi/storage/accounts/cosmosdb/accounts_table.go
@@ -16,159 +16,264 @@ package cosmosdb
 
 import (
 	"context"
-	"database/sql"
+	"errors"
+	"fmt"
 	"time"
 
+	"github.com/matrix-org/dendrite/internal/cosmosdbapi"
+
 	"github.com/matrix-org/dendrite/clientapi/userutil"
-	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
-
-	log "github.com/sirupsen/logrus"
 )
 
-const accountsSchema = `
--- Stores data about accounts.
-CREATE TABLE IF NOT EXISTS account_accounts (
-    -- The Matrix user ID localpart for this account
-    localpart TEXT NOT NULL PRIMARY KEY,
-    -- When this account was first created, as a unix timestamp (ms resolution).
-    created_ts BIGINT NOT NULL,
-    -- The password hash for this account. Can be NULL if this is a passwordless account.
-    password_hash TEXT,
-    -- Identifies which application service this account belongs to, if any.
-    appservice_id TEXT,
-    -- If the account is currently active
-    is_deactivated BOOLEAN DEFAULT 0
-    -- TODO:
-    -- is_guest, is_admin, upgraded_ts, devices, any email reset stuff?
-);
-`
+// const accountsSchema = `
+// -- Stores data about accounts.
+// CREATE TABLE IF NOT EXISTS account_accounts (
+//     -- The Matrix user ID localpart for this account
+//     localpart TEXT NOT NULL PRIMARY KEY,
+//     -- When this account was first created, as a unix timestamp (ms resolution).
+//     created_ts BIGINT NOT NULL,
+//     -- The password hash for this account. Can be NULL if this is a passwordless account.
+//     password_hash TEXT,
+//     -- Identifies which application service this account belongs to, if any.
+//     appservice_id TEXT,
+//     -- If the account is currently active
+//     is_deactivated BOOLEAN DEFAULT 0
+//     -- TODO:
+//     -- is_guest, is_admin, upgraded_ts, devices, any email reset stuff?
+// );
+// `
 
-const insertAccountSQL = "" +
-	"INSERT INTO account_accounts(localpart, created_ts, password_hash, appservice_id) VALUES ($1, $2, $3, $4)"
+type AccountExtended struct {
+	IsDeactivated bool   `json:"is_deactivated"`
+	PasswordHash  string `json:"password_hash"`
+	Created       int64  `json:"created_ts"`
+}
 
-const updatePasswordSQL = "" +
-	"UPDATE account_accounts SET password_hash = $1 WHERE localpart = $2"
+type AccountCosmosData struct {
+	Id             string          `json:"id"`
+	Pk             string          `json:"_pk"`
+	Cn             string          `json:"_cn"`
+	ETag           string          `json:"_etag"`
+	Timestamp      int64           `json:"_ts"`
+	Object         api.Account     `json:"_object"`
+	ObjectExtended AccountExtended `json:"_object_extended"`
+}
 
-const deactivateAccountSQL = "" +
-	"UPDATE account_accounts SET is_deactivated = 1 WHERE localpart = $1"
-
-const selectAccountByLocalpartSQL = "" +
-	"SELECT localpart, appservice_id FROM account_accounts WHERE localpart = $1"
-
-const selectPasswordHashSQL = "" +
-	"SELECT password_hash FROM account_accounts WHERE localpart = $1 AND is_deactivated = 0"
-
-const selectNewNumericLocalpartSQL = "" +
-	"SELECT COUNT(localpart) FROM account_accounts"
+type AccountCosmosUserCount struct {
+	UserCount int64 `json:"usercount"`
+}
 
 type accountsStatements struct {
-	db                            *sql.DB
-	insertAccountStmt             *sql.Stmt
-	updatePasswordStmt            *sql.Stmt
-	deactivateAccountStmt         *sql.Stmt
-	selectAccountByLocalpartStmt  *sql.Stmt
-	selectPasswordHashStmt        *sql.Stmt
-	selectNewNumericLocalpartStmt *sql.Stmt
-	serverName                    gomatrixserverlib.ServerName
+	db         *Database
+	tableName  string
+	serverName gomatrixserverlib.ServerName
 }
 
-func (s *accountsStatements) execSchema(db *sql.DB) error {
-	_, err := db.Exec(accountsSchema)
-	return err
-}
-
-func (s *accountsStatements) prepare(db *sql.DB, server gomatrixserverlib.ServerName) (err error) {
+func (s *accountsStatements) prepare(db *Database, server gomatrixserverlib.ServerName) (err error) {
 	s.db = db
-	if s.insertAccountStmt, err = db.Prepare(insertAccountSQL); err != nil {
-		return
-	}
-	if s.updatePasswordStmt, err = db.Prepare(updatePasswordSQL); err != nil {
-		return
-	}
-	if s.deactivateAccountStmt, err = db.Prepare(deactivateAccountSQL); err != nil {
-		return
-	}
-	if s.selectAccountByLocalpartStmt, err = db.Prepare(selectAccountByLocalpartSQL); err != nil {
-		return
-	}
-	if s.selectPasswordHashStmt, err = db.Prepare(selectPasswordHashSQL); err != nil {
-		return
-	}
-	if s.selectNewNumericLocalpartStmt, err = db.Prepare(selectNewNumericLocalpartSQL); err != nil {
-		return
-	}
+	s.tableName = "account_accounts"
 	s.serverName = server
 	return
+}
+
+func getAccount(s *accountsStatements, ctx context.Context, config cosmosdbapi.Tenant, pk string, docId string) (*AccountCosmosData, error) {
+	response := AccountCosmosData{}
+	var optionsGet = cosmosdbapi.GetGetDocumentOptions(pk)
+	var _, ex = cosmosdbapi.GetClient(s.db.connection).GetDocument(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		docId,
+		optionsGet,
+		&response)
+	return &response, ex
+}
+
+func setAccount(s *accountsStatements, ctx context.Context, config cosmosdbapi.Tenant, pk string, account AccountCosmosData) (*AccountCosmosData, error) {
+	response := AccountCosmosData{}
+	var optionsReplace = cosmosdbapi.GetReplaceDocumentOptions(pk, account.ETag)
+	var _, _, ex = cosmosdbapi.GetClient(s.db.connection).ReplaceDocument(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		account.Id,
+		&account,
+		optionsReplace)
+	return &response, ex
 }
 
 // insertAccount creates a new account. 'hash' should be the password hash for this account. If it is missing,
 // this account will be passwordless. Returns an error if this account already exists. Returns the account
 // on success.
 func (s *accountsStatements) insertAccount(
-	ctx context.Context, txn *sql.Tx, localpart, hash, appserviceID string,
+	ctx context.Context, localpart, hash, appserviceID string,
 ) (*api.Account, error) {
 	createdTimeMS := time.Now().UnixNano() / 1000000
-	stmt := s.insertAccountStmt
+	// stmt := s.insertAccountStmt
 
-	var err error
-	if appserviceID == "" {
-		_, err = sqlutil.TxStmt(txn, stmt).ExecContext(ctx, localpart, createdTimeMS, hash, nil)
-	} else {
-		_, err = sqlutil.TxStmt(txn, stmt).ExecContext(ctx, localpart, createdTimeMS, hash, appserviceID)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return &api.Account{
+	var result = api.Account{
 		Localpart:    localpart,
 		UserID:       userutil.MakeUserID(localpart, s.serverName),
 		ServerName:   s.serverName,
 		AppServiceID: appserviceID,
-	}, nil
+	}
+
+	var extended = AccountExtended{
+		IsDeactivated: false,
+		PasswordHash:  hash,
+		Created:       createdTimeMS,
+	}
+
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.accounts.tableName)
+
+	var dbData = AccountCosmosData{
+		Id:             cosmosdbapi.GetDocumentId(config.TenantName, dbCollectionName, result.Localpart),
+		Cn:             dbCollectionName,
+		Pk:             cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName),
+		Timestamp:      time.Now().Unix(),
+		Object:         result,
+		ObjectExtended: extended,
+	}
+
+	var options = cosmosdbapi.GetCreateDocumentOptions(dbData.Pk)
+	var _, _, err = cosmosdbapi.GetClient(s.db.connection).CreateDocument(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		dbData,
+		options)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
 }
 
 func (s *accountsStatements) updatePassword(
 	ctx context.Context, localpart, passwordHash string,
 ) (err error) {
-	_, err = s.updatePasswordStmt.ExecContext(ctx, passwordHash, localpart)
+
+	// "UPDATE account_accounts SET password_hash = $1 WHERE localpart = $2"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.accounts.tableName)
+	var docId = cosmosdbapi.GetDocumentId(config.TenantName, dbCollectionName, localpart)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+
+	var response, exGet = getAccount(s, ctx, config, pk, docId)
+	if exGet != nil {
+		return exGet
+	}
+
+	response.ObjectExtended.PasswordHash = passwordHash
+
+	var _, exReplace = setAccount(s, ctx, config, pk, *response)
+	if exReplace != nil {
+		return exReplace
+	}
 	return
 }
 
 func (s *accountsStatements) deactivateAccount(
 	ctx context.Context, localpart string,
 ) (err error) {
-	_, err = s.deactivateAccountStmt.ExecContext(ctx, localpart)
+
+	// "UPDATE account_accounts SET is_deactivated = 1 WHERE localpart = $1"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.accounts.tableName)
+	var docId = cosmosdbapi.GetDocumentId(config.TenantName, dbCollectionName, localpart)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+
+	var response, exGet = getAccount(s, ctx, config, pk, docId)
+	if exGet != nil {
+		return exGet
+	}
+
+	response.ObjectExtended.IsDeactivated = true
+
+	var _, exReplace = setAccount(s, ctx, config, pk, *response)
+	if exReplace != nil {
+		return exReplace
+	}
 	return
 }
 
 func (s *accountsStatements) selectPasswordHash(
 	ctx context.Context, localpart string,
 ) (hash string, err error) {
-	err = s.selectPasswordHashStmt.QueryRowContext(ctx, localpart).Scan(&hash)
-	return
+
+	// "SELECT password_hash FROM account_accounts WHERE localpart = $1 AND is_deactivated = 0"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.accounts.tableName)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+	response := []AccountCosmosData{}
+	var selectPasswordHashCosmos = "select * from c where c._cn = @x1 and c._object.Localpart = @x2 and c._object_extended.is_deactivated = false"
+	params := map[string]interface{}{
+		"@x1": dbCollectionName,
+		"@x2": localpart,
+	}
+	var options = cosmosdbapi.GetQueryDocumentsOptions(pk)
+	var query = cosmosdbapi.GetQuery(selectPasswordHashCosmos, params)
+	var _, ex = cosmosdbapi.GetClient(s.db.connection).QueryDocuments(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		query,
+		&response,
+		options)
+
+	if ex != nil {
+		return "", ex
+	}
+
+	if len(response) == 0 {
+		return "", errors.New(fmt.Sprintf("Localpart %s not found", localpart))
+	}
+
+	if len(response) != 1 {
+		return "", errors.New(fmt.Sprintf("Localpart %s has multiple entries", localpart))
+	}
+
+	return response[0].ObjectExtended.PasswordHash, nil
 }
 
 func (s *accountsStatements) selectAccountByLocalpart(
 	ctx context.Context, localpart string,
 ) (*api.Account, error) {
-	var appserviceIDPtr sql.NullString
 	var acc api.Account
 
-	stmt := s.selectAccountByLocalpartStmt
-	err := stmt.QueryRowContext(ctx, localpart).Scan(&acc.Localpart, &appserviceIDPtr)
-	if err != nil {
-		if err != sql.ErrNoRows {
-			log.WithError(err).Error("Unable to retrieve user from the db")
-		}
-		return nil, err
+	// "SELECT localpart, appservice_id FROM account_accounts WHERE localpart = $1"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.accounts.tableName)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+	response := []AccountCosmosData{}
+	var selectPasswordHashCosmos = "select * from c where c._cn = @x1 and c._object.Localpart = @x2"
+	params := map[string]interface{}{
+		"@x1": dbCollectionName,
+		"@x2": localpart,
 	}
-	if appserviceIDPtr.Valid {
-		acc.AppServiceID = appserviceIDPtr.String
+	var options = cosmosdbapi.GetQueryDocumentsOptions(pk)
+	var query = cosmosdbapi.GetQuery(selectPasswordHashCosmos, params)
+	var _, ex = cosmosdbapi.GetClient(s.db.connection).QueryDocuments(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		query,
+		&response,
+		options)
+
+	if ex != nil {
+		return nil, ex
 	}
 
+	if len(response) == 0 {
+		return nil, nil
+	}
+
+	acc = response[0].Object
 	acc.UserID = userutil.MakeUserID(localpart, s.serverName)
 	acc.ServerName = s.serverName
 
@@ -176,12 +281,31 @@ func (s *accountsStatements) selectAccountByLocalpart(
 }
 
 func (s *accountsStatements) selectNewNumericLocalpart(
-	ctx context.Context, txn *sql.Tx,
+	ctx context.Context,
 ) (id int64, err error) {
-	stmt := s.selectNewNumericLocalpartStmt
-	if txn != nil {
-		stmt = sqlutil.TxStmt(txn, stmt)
+
+	// 	"SELECT COUNT(localpart) FROM account_accounts"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.accounts.tableName)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+	var response []AccountCosmosUserCount
+	var selectCountCosmos = "select count(c._ts) as usercount from c where c._cn = @x1"
+	params := map[string]interface{}{
+		"@x1": dbCollectionName,
 	}
-	err = stmt.QueryRowContext(ctx).Scan(&id)
-	return
+	var options = cosmosdbapi.GetQueryDocumentsOptions(pk)
+	var query = cosmosdbapi.GetQuery(selectCountCosmos, params)
+	var _, ex = cosmosdbapi.GetClient(s.db.connection).QueryDocuments(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		query,
+		&response,
+		options)
+
+	if ex != nil {
+		return -1, ex
+	}
+
+	return int64(response[0].UserCount), nil
 }

--- a/userapi/storage/accounts/cosmosdb/openid_table.go
+++ b/userapi/storage/accounts/cosmosdb/openid_table.go
@@ -1,42 +1,70 @@
 package cosmosdb
 
 import (
-	"time"
-	"github.com/matrix-org/dendrite/internal/cosmosdbapi"
 	"context"
+	"time"
+
+	"github.com/matrix-org/dendrite/internal/cosmosdbapi"
 
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-const openIDTokenSchema = `
--- Stores data about accounts.
-CREATE TABLE IF NOT EXISTS open_id_tokens (
-	-- The value of the token issued to a user
-	token TEXT NOT NULL PRIMARY KEY,
-    -- The Matrix user ID for this account
-	localpart TEXT NOT NULL,
-	-- When the token expires, as a unix timestamp (ms resolution).
-	token_expires_at_ms BIGINT NOT NULL
-);
-`
+// const openIDTokenSchema = `
+// -- Stores data about accounts.
+// CREATE TABLE IF NOT EXISTS open_id_tokens (
+// 	-- The value of the token issued to a user
+// 	token TEXT NOT NULL PRIMARY KEY,
+//     -- The Matrix user ID for this account
+// 	localpart TEXT NOT NULL,
+// 	-- When the token expires, as a unix timestamp (ms resolution).
+// 	token_expires_at_ms BIGINT NOT NULL
+// );
+// `
+
+// OpenIDToken represents an OpenID token
+type OpenIDTokenCosmos struct {
+	Token       string `json:"token"`
+	UserID      string `json:"user_id"`
+	ExpiresAtMS int64  `json:"expires_at"`
+}
+
 type OpenIdTokenCosmosData struct {
-	Id string `json:"id"`
-	Pk string `json:"_pk"`
-	Cn string `json:"_cn"`
-	ETag string `json:"_etag"`
-	Timestamp int64 `json:"_ts"`
-	Object *api.OpenIDToken `json:"_object"`
+	Id          string            `json:"id"`
+	Pk          string            `json:"_pk"`
+	Cn          string            `json:"_cn"`
+	ETag        string            `json:"_etag"`
+	Timestamp   int64             `json:"_ts"`
+	OpenIdToken OpenIDTokenCosmos `json:"mx_userapi_openidtoken"`
 }
 
 type tokenStatements struct {
-	db              	*Database
-	tableName	 		string 
-	serverName      	gomatrixserverlib.ServerName
+	db *Database
+	// insertTokenStmt *sql.Stmt
+	selectTokenStmt string
+	tableName       string
+	serverName      gomatrixserverlib.ServerName
+}
+
+func mapFromToken(db OpenIDTokenCosmos) api.OpenIDToken {
+	return api.OpenIDToken{
+		ExpiresAtMS: db.ExpiresAtMS,
+		Token:       db.Token,
+		UserID:      db.UserID,
+	}
+}
+
+func mapToToken(api api.OpenIDToken) OpenIDTokenCosmos {
+	return OpenIDTokenCosmos{
+		ExpiresAtMS: api.ExpiresAtMS,
+		Token:       api.Token,
+		UserID:      api.UserID,
+	}
 }
 
 func (s *tokenStatements) prepare(db *Database, server gomatrixserverlib.ServerName) (err error) {
 	s.db = db
+	s.selectTokenStmt = "select * from c where c._cn = @x1 and c.mx_userapi_openidtoken.token = @x2"
 	s.tableName = "open_id_tokens"
 	s.serverName = server
 	return
@@ -52,29 +80,29 @@ func (s *tokenStatements) insertToken(
 
 	// "INSERT INTO open_id_tokens(token, localpart, token_expires_at_ms) VALUES ($1, $2, $3)"
 	var result = &api.OpenIDToken{
-		UserID:				localpart,
-		Token:				token,
-		ExpiresAtMS:		expiresAtMS,	
+		UserID:      localpart,
+		Token:       token,
+		ExpiresAtMS: expiresAtMS,
 	}
 
 	var config = cosmosdbapi.DefaultConfig()
 	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.openIDTokens.tableName)
 
 	var dbData = OpenIdTokenCosmosData{
-		Id: cosmosdbapi.GetDocumentId(config.TenantName, dbCollectionName, result.Token),
-		Cn: dbCollectionName,
-		Pk: cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName),
-		Timestamp: time.Now().Unix(),
-		Object: result,
+		Id:          cosmosdbapi.GetDocumentId(config.TenantName, dbCollectionName, result.Token),
+		Cn:          dbCollectionName,
+		Pk:          cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName),
+		Timestamp:   time.Now().Unix(),
+		OpenIdToken: mapToToken(*result),
 	}
 
 	var options = cosmosdbapi.GetCreateDocumentOptions(dbData.Pk)
 	var _, _, ex = cosmosdbapi.GetClient(s.db.connection).CreateDocument(
-			ctx, 
-			config.DatabaseName, 
-			config.TenantName, 
-			dbData, 
-			options)
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		dbData,
+		options)
 
 	if ex != nil {
 		return ex
@@ -96,32 +124,31 @@ func (s *tokenStatements) selectOpenIDTokenAtrributes(
 	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.openIDTokens.tableName)
 	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
 	response := []OpenIdTokenCosmosData{}
-	var selectOpenIdTokenCosmos = "select * from c where c._cn = @x1 and c._object.Token = @x2"
 	params := map[string]interface{}{
 		"@x1": dbCollectionName,
 		"@x2": token,
 	}
 	var options = cosmosdbapi.GetQueryDocumentsOptions(pk)
-	var query = cosmosdbapi.GetQuery(selectOpenIdTokenCosmos, params)
+	var query = cosmosdbapi.GetQuery(s.selectTokenStmt, params)
 	var _, ex = cosmosdbapi.GetClient(s.db.connection).QueryDocuments(
-			ctx, 
-			config.DatabaseName, 
-			config.TenantName,
-			query,
-			&response,
-			options)
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		query,
+		&response,
+		options)
 
 	if ex != nil {
 		return nil, ex
 	}
 
-	if(len(response) == 0) {
+	if len(response) == 0 {
 		return nil, nil
 	}
 
-	var openIdToken = response[0].Object
+	var openIdToken = response[0].OpenIdToken
 	openIDTokenAttrs = api.OpenIDTokenAttributes{
-		UserID: openIdToken.UserID,
+		UserID:      openIdToken.UserID,
 		ExpiresAtMS: openIdToken.ExpiresAtMS,
 	}
 	return &openIDTokenAttrs, nil

--- a/userapi/storage/accounts/cosmosdb/profile_table.go
+++ b/userapi/storage/accounts/cosmosdb/profile_table.go
@@ -16,107 +16,186 @@ package cosmosdb
 
 import (
 	"context"
-	"database/sql"
+	"errors"
 	"fmt"
+	"time"
+
+	"github.com/matrix-org/dendrite/internal/cosmosdbapi"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
-	"github.com/matrix-org/dendrite/internal"
-	"github.com/matrix-org/dendrite/internal/sqlutil"
 )
 
-const profilesSchema = `
--- Stores data about accounts profiles.
-CREATE TABLE IF NOT EXISTS account_profiles (
-    -- The Matrix user ID localpart for this account
-    localpart TEXT NOT NULL PRIMARY KEY,
-    -- The display name for this account
-    display_name TEXT,
-    -- The URL of the avatar for this account
-    avatar_url TEXT
-);
-`
+// const profilesSchema = `
+// -- Stores data about accounts profiles.
+// CREATE TABLE IF NOT EXISTS account_profiles (
+//     -- The Matrix user ID localpart for this account
+//     localpart TEXT NOT NULL PRIMARY KEY,
+//     -- The display name for this account
+//     display_name TEXT,
+//     -- The URL of the avatar for this account
+//     avatar_url TEXT
+// );
+// `
 
-const insertProfileSQL = "" +
-	"INSERT INTO account_profiles(localpart, display_name, avatar_url) VALUES ($1, $2, $3)"
-
-const selectProfileByLocalpartSQL = "" +
-	"SELECT localpart, display_name, avatar_url FROM account_profiles WHERE localpart = $1"
-
-const setAvatarURLSQL = "" +
-	"UPDATE account_profiles SET avatar_url = $1 WHERE localpart = $2"
-
-const setDisplayNameSQL = "" +
-	"UPDATE account_profiles SET display_name = $1 WHERE localpart = $2"
-
-const selectProfilesBySearchSQL = "" +
-	"SELECT localpart, display_name, avatar_url FROM account_profiles WHERE localpart LIKE $1 OR display_name LIKE $1 LIMIT $2"
-
-type profilesStatements struct {
-	db                           *sql.DB
-	insertProfileStmt            *sql.Stmt
-	selectProfileByLocalpartStmt *sql.Stmt
-	setAvatarURLStmt             *sql.Stmt
-	setDisplayNameStmt           *sql.Stmt
-	selectProfilesBySearchStmt   *sql.Stmt
+type ProfileCosmosData struct {
+	Id        string            `json:"id"`
+	Pk        string            `json:"_pk"`
+	Cn        string            `json:"_cn"`
+	ETag      string            `json:"_etag"`
+	Timestamp int64             `json:"_ts"`
+	Object    authtypes.Profile `json:"_object"`
 }
 
-func (s *profilesStatements) prepare(db *sql.DB) (err error) {
+type profilesStatements struct {
+	db        *Database
+	tableName string
+}
+
+func (s *profilesStatements) prepare(db *Database) (err error) {
 	s.db = db
-	_, err = db.Exec(profilesSchema)
-	if err != nil {
-		return
-	}
-	if s.insertProfileStmt, err = db.Prepare(insertProfileSQL); err != nil {
-		return
-	}
-	if s.selectProfileByLocalpartStmt, err = db.Prepare(selectProfileByLocalpartSQL); err != nil {
-		return
-	}
-	if s.setAvatarURLStmt, err = db.Prepare(setAvatarURLSQL); err != nil {
-		return
-	}
-	if s.setDisplayNameStmt, err = db.Prepare(setDisplayNameSQL); err != nil {
-		return
-	}
-	if s.selectProfilesBySearchStmt, err = db.Prepare(selectProfilesBySearchSQL); err != nil {
-		return
-	}
+	s.tableName = "account_profiles"
 	return
 }
 
+func getProfile(s *profilesStatements, ctx context.Context, config cosmosdbapi.Tenant, pk string, docId string) (*ProfileCosmosData, error) {
+	response := ProfileCosmosData{}
+	var optionsGet = cosmosdbapi.GetGetDocumentOptions(pk)
+	var _, ex = cosmosdbapi.GetClient(s.db.connection).GetDocument(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		docId,
+		optionsGet,
+		&response)
+	return &response, ex
+}
+
+func setProfile(s *profilesStatements, ctx context.Context, config cosmosdbapi.Tenant, pk string, profile ProfileCosmosData) (*ProfileCosmosData, error) {
+	var optionsReplace = cosmosdbapi.GetReplaceDocumentOptions(pk, profile.ETag)
+	var _, _, ex = cosmosdbapi.GetClient(s.db.connection).ReplaceDocument(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		profile.Id,
+		&profile,
+		optionsReplace)
+	return &profile, ex
+}
+
 func (s *profilesStatements) insertProfile(
-	ctx context.Context, txn *sql.Tx, localpart string,
+	ctx context.Context, localpart string,
 ) error {
-	_, err := sqlutil.TxStmt(txn, s.insertProfileStmt).ExecContext(ctx, localpart, "", "")
+
+	// 	"INSERT INTO account_profiles(localpart, display_name, avatar_url) VALUES ($1, $2, $3)"
+	var result = &authtypes.Profile{
+		Localpart: localpart,
+	}
+
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.profiles.tableName)
+
+	var dbData = ProfileCosmosData{
+		Id:        cosmosdbapi.GetDocumentId(config.TenantName, dbCollectionName, result.Localpart),
+		Cn:        dbCollectionName,
+		Pk:        cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName),
+		Timestamp: time.Now().Unix(),
+		Object:    *result,
+	}
+
+	var options = cosmosdbapi.GetCreateDocumentOptions(dbData.Pk)
+	var _, _, err = cosmosdbapi.GetClient(s.db.connection).CreateDocument(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		dbData,
+		options)
+
 	return err
 }
 
 func (s *profilesStatements) selectProfileByLocalpart(
 	ctx context.Context, localpart string,
 ) (*authtypes.Profile, error) {
-	var profile authtypes.Profile
-	err := s.selectProfileByLocalpartStmt.QueryRowContext(ctx, localpart).Scan(
-		&profile.Localpart, &profile.DisplayName, &profile.AvatarURL,
-	)
-	if err != nil {
-		return nil, err
+
+	// "SELECT localpart, display_name, avatar_url FROM account_profiles WHERE localpart = $1"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.profiles.tableName)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+	response := []ProfileCosmosData{}
+	var selectProfileByLocalpartCosmos = "select * from c where c._cn = @x1 and c._object.local_part = @x2"
+	params := map[string]interface{}{
+		"@x1": dbCollectionName,
+		"@x2": localpart,
 	}
-	return &profile, nil
+	var options = cosmosdbapi.GetQueryDocumentsOptions(pk)
+	var query = cosmosdbapi.GetQuery(selectProfileByLocalpartCosmos, params)
+	var _, ex = cosmosdbapi.GetClient(s.db.connection).QueryDocuments(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		query,
+		&response,
+		options)
+
+	if ex != nil {
+		return nil, ex
+	}
+
+	if len(response) == 0 {
+		return nil, errors.New(fmt.Sprintf("Localpart %s not found", len(response)))
+	}
+
+	if len(response) != 1 {
+		return nil, errors.New(fmt.Sprintf("Localpart %s has multiple entries", len(response)))
+	}
+
+	return &response[0].Object, nil
 }
 
 func (s *profilesStatements) setAvatarURL(
-	ctx context.Context, txn *sql.Tx, localpart string, avatarURL string,
+	ctx context.Context, localpart string, avatarURL string,
 ) (err error) {
-	stmt := sqlutil.TxStmt(txn, s.setAvatarURLStmt)
-	_, err = stmt.ExecContext(ctx, avatarURL, localpart)
+
+	// "UPDATE account_profiles SET avatar_url = $1 WHERE localpart = $2"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.profiles.tableName)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+	var docId = cosmosdbapi.GetDocumentId(config.TenantName, dbCollectionName, localpart)
+
+	var response, exGet = getProfile(s, ctx, config, pk, docId)
+	if exGet != nil {
+		return exGet
+	}
+
+	response.Object.AvatarURL = avatarURL
+
+	var _, exReplace = setProfile(s, ctx, config, pk, *response)
+	if exReplace != nil {
+		return exReplace
+	}
 	return
 }
 
 func (s *profilesStatements) setDisplayName(
-	ctx context.Context, txn *sql.Tx, localpart string, displayName string,
+	ctx context.Context, localpart string, displayName string,
 ) (err error) {
-	stmt := sqlutil.TxStmt(txn, s.setDisplayNameStmt)
-	_, err = stmt.ExecContext(ctx, displayName, localpart)
+
+	// "UPDATE account_profiles SET display_name = $1 WHERE localpart = $2"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.profiles.tableName)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+	var docId = cosmosdbapi.GetDocumentId(config.TenantName, dbCollectionName, localpart)
+	var response, exGet = getProfile(s, ctx, config, pk, docId)
+	if exGet != nil {
+		return exGet
+	}
+
+	response.Object.DisplayName = displayName
+
+	var _, exReplace = setProfile(s, ctx, config, pk, *response)
+	if exReplace != nil {
+		return exReplace
+	}
 	return
 }
 
@@ -124,20 +203,36 @@ func (s *profilesStatements) selectProfilesBySearch(
 	ctx context.Context, searchString string, limit int,
 ) ([]authtypes.Profile, error) {
 	var profiles []authtypes.Profile
-	// The fmt.Sprintf directive below is building a parameter for the
-	// "LIKE" condition in the SQL query. %% escapes the % char, so the
-	// statement in the end will look like "LIKE %searchString%".
-	rows, err := s.selectProfilesBySearchStmt.QueryContext(ctx, fmt.Sprintf("%%%s%%", searchString), limit)
-	if err != nil {
-		return nil, err
+
+	// "SELECT localpart, display_name, avatar_url FROM account_profiles WHERE localpart LIKE $1 OR display_name LIKE $1 LIMIT $2"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.profiles.tableName)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+	response := []ProfileCosmosData{}
+	var selectProfileByLocalpartCosmos = "select top @x3 * from c where c._cn = @x1 and contains(c._object.local_part, @x2)"
+	params := map[string]interface{}{
+		"@x1": dbCollectionName,
+		"@x2": searchString,
+		"@x3": limit,
 	}
-	defer internal.CloseAndLogIfError(ctx, rows, "selectProfilesBySearch: rows.close() failed")
-	for rows.Next() {
-		var profile authtypes.Profile
-		if err := rows.Scan(&profile.Localpart, &profile.DisplayName, &profile.AvatarURL); err != nil {
-			return nil, err
-		}
-		profiles = append(profiles, profile)
+	var options = cosmosdbapi.GetQueryDocumentsOptions(pk)
+	var query = cosmosdbapi.GetQuery(selectProfileByLocalpartCosmos, params)
+	var _, ex = cosmosdbapi.GetClient(s.db.connection).QueryDocuments(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		query,
+		&response,
+		options)
+
+	if ex != nil {
+		return nil, ex
 	}
+
+	for i := 0; i < len(response); i++ {
+		var responseData = response[i]
+		profiles = append(profiles, responseData.Object)
+	}
+
 	return profiles, nil
 }

--- a/userapi/storage/accounts/cosmosdb/threepid_table.go
+++ b/userapi/storage/accounts/cosmosdb/threepid_table.go
@@ -16,118 +16,186 @@ package cosmosdb
 
 import (
 	"context"
-	"database/sql"
+	"fmt"
+	"time"
 
-	"github.com/matrix-org/dendrite/internal"
-	"github.com/matrix-org/dendrite/internal/sqlutil"
+	"github.com/matrix-org/dendrite/internal/cosmosdbapi"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 )
 
-const threepidSchema = `
--- Stores data about third party identifiers
-CREATE TABLE IF NOT EXISTS account_threepid (
-	-- The third party identifier
-	threepid TEXT NOT NULL,
-	-- The 3PID medium
-	medium TEXT NOT NULL DEFAULT 'email',
-	-- The localpart of the Matrix user ID associated to this 3PID
-	localpart TEXT NOT NULL,
+// const threepidSchema = `
+// -- Stores data about third party identifiers
+// CREATE TABLE IF NOT EXISTS account_threepid (
+// 	-- The third party identifier
+// 	threepid TEXT NOT NULL,
+// 	-- The 3PID medium
+// 	medium TEXT NOT NULL DEFAULT 'email',
+// 	-- The localpart of the Matrix user ID associated to this 3PID
+// 	localpart TEXT NOT NULL,
 
-	PRIMARY KEY(threepid, medium)
-);
+// 	PRIMARY KEY(threepid, medium)
+// );
 
-CREATE INDEX IF NOT EXISTS account_threepid_localpart ON account_threepid(localpart);
-`
-
-const selectLocalpartForThreePIDSQL = "" +
-	"SELECT localpart FROM account_threepid WHERE threepid = $1 AND medium = $2"
-
-const selectThreePIDsForLocalpartSQL = "" +
-	"SELECT threepid, medium FROM account_threepid WHERE localpart = $1"
-
-const insertThreePIDSQL = "" +
-	"INSERT INTO account_threepid (threepid, medium, localpart) VALUES ($1, $2, $3)"
-
-const deleteThreePIDSQL = "" +
-	"DELETE FROM account_threepid WHERE threepid = $1 AND medium = $2"
-
-type threepidStatements struct {
-	db                              *sql.DB
-	selectLocalpartForThreePIDStmt  *sql.Stmt
-	selectThreePIDsForLocalpartStmt *sql.Stmt
-	insertThreePIDStmt              *sql.Stmt
-	deleteThreePIDStmt              *sql.Stmt
+type ThreePIDObject struct {
+	Localpart string `json:"local_part"`
+	ThreePID  string `json:"three_pid"`
+	Medium    string `json:"medium"`
 }
 
-func (s *threepidStatements) prepare(db *sql.DB) (err error) {
-	s.db = db
-	_, err = db.Exec(threepidSchema)
-	if err != nil {
-		return
-	}
-	if s.selectLocalpartForThreePIDStmt, err = db.Prepare(selectLocalpartForThreePIDSQL); err != nil {
-		return
-	}
-	if s.selectThreePIDsForLocalpartStmt, err = db.Prepare(selectThreePIDsForLocalpartSQL); err != nil {
-		return
-	}
-	if s.insertThreePIDStmt, err = db.Prepare(insertThreePIDSQL); err != nil {
-		return
-	}
-	if s.deleteThreePIDStmt, err = db.Prepare(deleteThreePIDSQL); err != nil {
-		return
-	}
+type ThreePIDCosmosData struct {
+	Id        string         `json:"id"`
+	Pk        string         `json:"_pk"`
+	Cn        string         `json:"_cn"`
+	ETag      string         `json:"_etag"`
+	Timestamp int64          `json:"_ts"`
+	Object    ThreePIDObject `json:"_object"`
+}
 
+type threepidStatements struct {
+	db        *Database
+	tableName string
+}
+
+func (s *threepidStatements) prepare(db *Database) (err error) {
+	s.db = db
+	s.tableName = "account_threepid"
 	return
 }
 
 func (s *threepidStatements) selectLocalpartForThreePID(
-	ctx context.Context, txn *sql.Tx, threepid string, medium string,
+	ctx context.Context, threepid string, medium string,
 ) (localpart string, err error) {
-	stmt := sqlutil.TxStmt(txn, s.selectLocalpartForThreePIDStmt)
-	err = stmt.QueryRowContext(ctx, threepid, medium).Scan(&localpart)
-	if err == sql.ErrNoRows {
+
+	// "SELECT localpart FROM account_threepid WHERE threepid = $1 AND medium = $2"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.threepids.tableName)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+	response := []ThreePIDCosmosData{}
+	var selectLocalPartThreePIDCosmos = "select * from c where c._cn = @x1 and c._object.three_pid = @x2 and c._object.medium = @x3"
+	params := map[string]interface{}{
+		"@x1": dbCollectionName,
+		"@x2": threepid,
+		"@x3": medium,
+	}
+	var options = cosmosdbapi.GetQueryDocumentsOptions(pk)
+	var query = cosmosdbapi.GetQuery(selectLocalPartThreePIDCosmos, params)
+	var _, ex = cosmosdbapi.GetClient(s.db.connection).QueryDocuments(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		query,
+		&response,
+		options)
+
+	if ex != nil {
+		return "", ex
+	}
+
+	if len(response) == 0 {
 		return "", nil
 	}
-	return
+
+	return response[0].Object.Localpart, nil
 }
 
 func (s *threepidStatements) selectThreePIDsForLocalpart(
 	ctx context.Context, localpart string,
 ) (threepids []authtypes.ThreePID, err error) {
-	rows, err := s.selectThreePIDsForLocalpartStmt.QueryContext(ctx, localpart)
-	if err != nil {
-		return
+
+	// "SELECT threepid, medium FROM account_threepid WHERE localpart = $1"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.threepids.tableName)
+	var pk = cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+	response := []ThreePIDCosmosData{}
+	var selectThreePIDLocalPartCosmos = "select * from c where c._cn = @x1 and c._object.local_part = @x2"
+	params := map[string]interface{}{
+		"@x1": dbCollectionName,
+		"@x2": localpart,
 	}
-	defer internal.CloseAndLogIfError(ctx, rows, "selectThreePIDsForLocalpart: rows.close() failed")
+	var options = cosmosdbapi.GetQueryDocumentsOptions(pk)
+	var query = cosmosdbapi.GetQuery(selectThreePIDLocalPartCosmos, params)
+	var _, ex = cosmosdbapi.GetClient(s.db.connection).QueryDocuments(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		query,
+		&response,
+		options)
+
+	if ex != nil {
+		return threepids, ex
+	}
+
+	if len(response) == 0 {
+		return threepids, nil
+	}
 
 	threepids = []authtypes.ThreePID{}
-	for rows.Next() {
-		var threepid string
-		var medium string
-		if err = rows.Scan(&threepid, &medium); err != nil {
-			return
-		}
+	for _, item := range response {
 		threepids = append(threepids, authtypes.ThreePID{
-			Address: threepid,
-			Medium:  medium,
+			Address: item.Object.ThreePID,
+			Medium:  item.Object.Medium,
 		})
 	}
-	return threepids, rows.Err()
+	return threepids, nil
 }
 
 func (s *threepidStatements) insertThreePID(
-	ctx context.Context, txn *sql.Tx, threepid, medium, localpart string,
+	ctx context.Context, threepid, medium, localpart string,
 ) (err error) {
-	stmt := sqlutil.TxStmt(txn, s.insertThreePIDStmt)
-	_, err = stmt.ExecContext(ctx, threepid, medium, localpart)
-	return err
+
+	// "INSERT INTO account_threepid (threepid, medium, localpart) VALUES ($1, $2, $3)"
+	var result = ThreePIDObject{
+		Localpart: localpart,
+		Medium:    medium,
+		ThreePID:  threepid,
+	}
+
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.accounts.tableName)
+
+	id := fmt.Sprintf("%s_%s", threepid, medium)
+	var dbData = ThreePIDCosmosData{
+		Id:        cosmosdbapi.GetDocumentId(config.TenantName, dbCollectionName, id),
+		Cn:        dbCollectionName,
+		Pk:        cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName),
+		Timestamp: time.Now().Unix(),
+		Object:    result,
+	}
+
+	var options = cosmosdbapi.GetCreateDocumentOptions(dbData.Pk)
+	_, _, err = cosmosdbapi.GetClient(s.db.connection).CreateDocument(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		dbData,
+		options)
+
+	if err != nil {
+		return err
+	}
+	return
 }
 
 func (s *threepidStatements) deleteThreePID(
-	ctx context.Context, txn *sql.Tx, threepid string, medium string) (err error) {
-	stmt := sqlutil.TxStmt(txn, s.deleteThreePIDStmt)
-	_, err = stmt.ExecContext(ctx, threepid, medium)
-	return err
+	ctx context.Context, threepid string, medium string) (err error) {
+
+	// "DELETE FROM account_threepid WHERE threepid = $1 AND medium = $2"
+	var config = cosmosdbapi.DefaultConfig()
+	var dbCollectionName = cosmosdbapi.GetCollectionName(s.db.databaseName, s.db.accounts.tableName)
+	id := fmt.Sprintf("%s_%s", threepid, medium)
+	pk := cosmosdbapi.GetPartitionKey(config.TenantName, dbCollectionName)
+	var options = cosmosdbapi.GetDeleteDocumentOptions(pk)
+	_, err = cosmosdbapi.GetClient(s.db.connection).DeleteDocument(
+		ctx,
+		config.DatabaseName,
+		config.TenantName,
+		id,
+		options)
+
+	if err != nil {
+		return err
+	}
+	return
 }


### PR DESCRIPTION
This implements userapi/accounts using Cosmos DB
It uses an public GO Azure CosmosDB library to perform the heavy lifting (vippsas/go-cosmosdb)
The external library is abstracted behind an internal "cosmosdbapi" package
The changes were made to change over in a piece-meal fashion;
- YAML changed specifically for account_database ONLY to use cosmosdb:
- ConnectionString in YAML used to connect
- Accounts tables refactored to use CosmosDB and de-reference SQL
- Uses the shared "cosmosdbapi" internal package
- Tenancy is "hacked" using a static class to store the DB and Container (for now) - in tenant.go

The results allow the user to register, update settings and search
![image](https://user-images.githubusercontent.com/75228224/117757835-345e4880-b264-11eb-87a5-175633bd4764.png)

Data is stored for each table in a separate Cosmos collection of docs, in a similar way to SafeZone
- All IDs are prefixed with "matrix_"
- The tenant name is injected in the same spot in the id and pk as per SZ
- The actual data objects are stored as property named in a similar way to SZ (thanks @jahmai-ca)
- eg AccountCosmos is the internal POCO for accounts which is a property on the AccountCosmosData that is stored in the DB
- ETags were used when updating data
- SELECT queries were used in-place of the existing SQL 
- (eg select * from c where c._cn = "matrix_userapi_account_accounts")
![image](https://user-images.githubusercontent.com/75228224/117757991-7ab3a780-b264-11eb-8c14-1d4b78d5af72.png)

- Add GO CosmosDB library github.com/vippsas/go-cosmosdb
- Update YAML file to use file: everywhere except for Accounts
- Use the CosmosDB conn string in the YAML
- Add cosmosdbapi package to wrap the external package
- Add Tenant.go to store the tenancy settings - to be removed when tenancy is implemented
- Update the 5 tables to use the internal CosmosDBAPI package instead of SQL
- Remove sql from storage.go and other files
